### PR TITLE
Install 'linter' automatically upon first install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ linter-clojure
 This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [clojure-x.x.x.jar](http://clojure.org/). It will be used with files that have the “Clojure” syntax.
 
 ## Installation
-Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
+On first activation the plugin will install all dependencies automatically, you no longer have to worry about installing Linter.
 
 ## Settings
 You can configure linter-clojure by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -7,6 +7,9 @@ module.exports =
       type: 'string'
       default: 'clojure-x.x.x.jar'
 
+  activate: ->
+    require("atom-package-deps").install("linter-clojure")
+
   provideLinter: ->
     helpers = require('atom-linter')
     regex = 'RuntimeException:(?<message>.*), compiling:(.*):(?<line>\\d+):(?<col>\\d+)'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -8,7 +8,7 @@ module.exports =
       default: 'clojure-x.x.x.jar'
 
   activate: ->
-    require("atom-package-deps").install("linter-clojure")
+    require('atom-package-deps').install()
 
   provideLinter: ->
     helpers = require('atom-linter')

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^3.2.0"
-  }
+    "atom-linter": "^3.2.0",
+    "atom-package-deps": "^2.0.1"
+  },
+  "package-deps": [
+    "linter"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "atom-linter": "^3.2.0",
-    "atom-package-deps": "^2.0.1"
+    "atom-package-deps": "^3.0.2"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Addresses AtomLinter/linter-clojure#7

Instead of a manual requirement for linter to be preinstalled,
use atom-package-deps to install 'linter' when activated (if not
already installed).  This allows for much simpler installation.