### PR TITLE
Don't mark as lintOnFly compatible

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -16,7 +16,7 @@ module.exports =
     provider =
       grammarScopes: ['source.clojure', 'source.clojurescript']
       scope: 'file'
-      lintOnFly: true
+      lintOnFly: false
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         command = atom.config.get('linter-clojure.javaExecutablePath') or 'java'


### PR DESCRIPTION
This linter is currently only operating on the file contents on disk, not the current editor contents. Mark lintOnFly as false till this can be investigated and possibly implemented correctly.

Fixes #34.